### PR TITLE
fix: 카드컴포넌트 및 구매페이지 데이터에 맞게 수정

### DIFF
--- a/src/app/purchase/[id]/page.jsx
+++ b/src/app/purchase/[id]/page.jsx
@@ -28,39 +28,19 @@ function PurchasePage() {
     return <div className="text-white text-center mt-10">로딩 중...</div>;
   }
 
-  const {
-    name,
-    description,
-    imageUrl,
-    grade,
-    genre,
-    sellerNickname,
-    price,
-    initialQuantity,
-    remainingQuantity,
-  } = photoCard;
-
-  const cards = [
-    {
-      cardGrade: grade,
-      cardGrade: genre,
-      nickname: sellerNickname,
-      photoDescription: description,
-      price: price,
-      quantityLeft: remainingQuantity,
-      quantityTotal: initialQuantity,
-    },
-  ];
+  const { name, imageUrl } = photoCard;
 
   return (
-    <div className="max-w-[744px] m-auto px-5 tablet:max-w-300 tablet:px-10 pc:px-0">
+    <div className="mx-auto w-[345px] tablet:w-[704px] pc:w-[1480px]">
       <NoHeader title="마켓플레이스" />
 
       <div className="mt-5 mb-[26px] tablet:mb-12 pc:mb-[70px]">
-        <h3 className="mb-[10px] font-bold text-2xl text-white">{name}</h3>
-        <hr />
+        <h3 className="mb-[10px] tablet:mb-5 font-bold text-2xl text-white">
+          {name}
+        </h3>
+        <hr className="border-2 border-gray100" />
       </div>
-      {/* 반응형 레이아웃 */}
+
       <div className="flex flex-col tablet:flex-row gap-5 pc:gap-20 mb-30">
         {/* 이미지 */}
         <div className="w-[345px] tablet:w-[342px] pc:w-240 h-[258.75px] tablet:h-[256.5px] pc:h-180 relative">
@@ -69,7 +49,7 @@ function PurchasePage() {
 
         {/* 카드 컴포넌트 */}
         <div className="w-full tablet:flex-1">
-          <CardProfile type="buyer" cards={cards} />
+          <CardProfile type="buyer" cards={[photoCard]} />
         </div>
       </div>
     </div>

--- a/src/components/ui/card/cardProfile/BuyerCardItem.jsx
+++ b/src/components/ui/card/cardProfile/BuyerCardItem.jsx
@@ -5,7 +5,7 @@ const BuyerCardItem = ({ card, quantity, onQuantityChange }) => {
   const totalPrice = card.price * (quantity || 0);
 
   const handleQuantityChange = (newValue) => {
-    onQuantityChange(card.cardGrade, newValue);
+    onQuantityChange(card.grade, newValue);
   };
 
   return (
@@ -15,7 +15,7 @@ const BuyerCardItem = ({ card, quantity, onQuantityChange }) => {
         <span className="font-normal text-[18px] pc:text-xl">구매수량</span>
         <CounterInput
           initialValue={quantity || 1}
-          max={card.quantityLeft}
+          max={card.remainingQuantity}
           showMaxInfo={false}
           onChange={handleQuantityChange}
           width="w-[144px] pc:w-[150px]"
@@ -26,7 +26,7 @@ const BuyerCardItem = ({ card, quantity, onQuantityChange }) => {
         <span>총 가격</span>
         <div className="flex justify-between items-center">
           <span className="font-bold text-xl pc:text-2xl text-white mr-[10px]">
-            {totalPrice}P
+            {totalPrice.toLocaleString()}P
           </span>
           <span className="font-normal text-[18px] pc:text-xl text-gray300">
             ({quantity || 0}장)

--- a/src/components/ui/card/cardProfile/CardBasicItem.jsx
+++ b/src/components/ui/card/cardProfile/CardBasicItem.jsx
@@ -1,38 +1,38 @@
 import Link from "next/link";
-import { formatCardGrade } from "@/utils/formatCardGrade"; // 경로는 프로젝트 구조에 맞게 조정
+import { formatCardGrade } from "@/utils/formatCardGrade";
 
 const CardBasicItem = ({ card, gradeStyles }) => (
   <div className="text-white bg-transparent">
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-[10px] font-bold text-[18px] pc:text-2xl">
-        <p className={gradeStyles[card.cardGrade]}>
-          {formatCardGrade(card.cardGrade)}
-        </p>
+        <p className={gradeStyles[card.grade]}>{formatCardGrade(card.grade)}</p>
         <div className="text-gray400">|</div>
-        <p>{card.CardGenre}</p>
+        <p className="text-gray300">{card.genre}</p>
       </div>
-
-      {/* 수정 예정 */}
       <Link href="/" className="underline">
-        <p className="font-bold text-[18px] pc:text-2xl">{card.nickname}</p>
+        <p className="font-bold text-[18px] pc:text-2xl">
+          {card.sellerNickname}
+        </p>
       </Link>
     </div>
     <hr className="my-[30px] text-gray400" />
-    <p className="text-sm mb-2 clamp-description">
-      {card.photoDescription || ""}
+    <p className="font-normal text-base pc:text-[18px] text-white ">
+      {card.description || ""}
     </p>
     <hr className="my-[30px] text-gray400" />
     <div className="mb-[10px] flex justify-between">
       <span className="font-normal text-[18px] pc:text-xl text-gray300">
         가격
       </span>
-      <p className="font-bold text-xl pc:text-2xl">{card.price}P</p>
+      <p className="font-bold text-xl pc:text-2xl">
+        {card.price.toLocaleString()}P
+      </p>
     </div>
     <div className="flex justify-between text-gray300">
       <span className="font-normal text-[18px] pc:text-xl">잔여</span>
       <p className="font-bold text-xl pc:text-2xl">
-        <span className="text-white">{card.quantityLeft}</span>/
-        {card.quantityTotal}
+        <span className="text-white">{card.remainingQuantity}</span>/
+        {card.initialQuantity}
       </p>
     </div>
   </div>

--- a/src/components/ui/card/cardProfile/CardDetailItem.jsx
+++ b/src/components/ui/card/cardProfile/CardDetailItem.jsx
@@ -4,7 +4,7 @@ const CardDetailItem = ({ card, quantity, onQuantityChange }) => {
   const gradeStyles = {
     COMMON: "text-main",
     RARE: "text-blue",
-    "SUPER RARE": "text-purple",
+    SUPER_RARE: "text-purple",
     LEGENDARY: "text-pink",
   };
 
@@ -12,19 +12,21 @@ const CardDetailItem = ({ card, quantity, onQuantityChange }) => {
     let val = parseInt(value, 10);
     if (isNaN(val) || val < 1) val = 1;
     if (val > card.initialQuantity) val = card.initialQuantity;
-    onQuantityChange(card.cardGrade, val);
+    onQuantityChange(card.grade, val);
   };
 
   return (
     <div className="text-white bg-transparent">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-[10px] font-bold text-[18px] pc:text-2xl">
-          <p className={gradeStyles[card.cardGrade]}>{card.cardGrade}</p>
+          <p className={gradeStyles[card.grade]}>{card.grade}</p>
           <div className="text-gray400">|</div>
-          <p>{card.CardGenre}</p>
+          <p>{card.genre}</p>
         </div>
         <Link href="/" className="underline">
-          <p className="font-bold text-[18px] pc:text-2xl">{card.nickname}</p>
+          <p className="font-bold text-[18px] pc:text-2xl">
+            {card.sellerNickname}
+          </p>
         </Link>
       </div>
       <hr className="my-[30px] text-gray400" />

--- a/src/components/ui/card/cardProfile/CardProfile.jsx
+++ b/src/components/ui/card/cardProfile/CardProfile.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState } from "react";
-
 import CardBasicItem from "./CardBasicItem";
 import BuyerCardItem from "./BuyerCardItem";
 import CardDetailItem from "./CardDetailItem";
@@ -17,26 +16,19 @@ const CardProfile = ({ type, cards }) => {
   const isBuyer = type === "buyer";
   const isDetail = type === "card_detail";
 
-  // 카드별 수량 상태 관리
   const [quantities, setQuantities] = useState(() =>
     cards.reduce((acc, card) => {
-      acc[card.cardGrade] = 1;
+      acc[card.grade] = 1;
       return acc;
     }, {})
   );
 
-  const handleQuantityChange = (cardGrade, value) => {
+  const handleQuantityChange = (grade, value) => {
     const parsed = parseInt(value, 10);
     if (!isNaN(parsed) && parsed > 0) {
-      setQuantities((prev) => ({
-        ...prev,
-        [cardGrade]: parsed,
-      }));
+      setQuantities((prev) => ({ ...prev, [grade]: parsed }));
     } else if (value === "") {
-      setQuantities((prev) => ({
-        ...prev,
-        [cardGrade]: "",
-      }));
+      setQuantities((prev) => ({ ...prev, [grade]: "" }));
     }
   };
 
@@ -45,9 +37,9 @@ const CardProfile = ({ type, cards }) => {
       {isDetail ? (
         cards.map((card) => (
           <CardDetailItem
-            key={card.cardGrade}
+            key={card.grade}
             card={card}
-            quantity={quantities[card.cardGrade] || 1}
+            quantity={quantities[card.grade] || 1}
             onQuantityChange={handleQuantityChange}
           />
         ))
@@ -55,7 +47,7 @@ const CardProfile = ({ type, cards }) => {
         <>
           {cards.map((card) => (
             <CardBasicItem
-              key={card.cardGrade}
+              key={card.grade}
               card={card}
               gradeStyles={gradeStyles}
             />
@@ -63,9 +55,9 @@ const CardProfile = ({ type, cards }) => {
           {isBuyer &&
             cards.map((card) => (
               <BuyerCardItem
-                key={`buyer-${card.cardGrade}`}
+                key={`buyer-${card.grade}`}
                 card={card}
-                quantity={quantities[card.cardGrade] || 1}
+                quantity={quantities[card.grade] || 1}
                 onQuantityChange={handleQuantityChange}
               />
             ))}


### PR DESCRIPTION
- 카드 컴포넌트 매핑 없이 사용가능하게 수정
- 자유분방한 디자인 수정
- 가격 3자리마다 쉼표 설정

![screencapture-localhost-3000-purchase-2-2025-05-22-09_19_59](https://github.com/user-attachments/assets/f8c178fe-4000-4bf1-9370-f847d8db886b)
