### PR TITLE
feat: 마이갤러리 UI 및 페이지네이션 기능 구현

### DIFF
--- a/src/app/market/page.jsx
+++ b/src/app/market/page.jsx
@@ -1,18 +1,17 @@
 'use client';
 
 import {useEffect, useState} from 'react';
-import {useQuery, useInfiniteQuery} from '@tanstack/react-query';
+import {useInfiniteQuery} from '@tanstack/react-query';
 import {useInView} from 'react-intersection-observer';
 import FilterBottomSheet from '@/components/market/FilterBottomSheet';
 import {SearchInput} from '@/components/ui/input';
 import {fetchMarketCards} from '@/lib/api/marketApi';
 import DropdownInput from '@/components/ui/input/DropdownInput';
 import Image from 'next/image';
-import Link from 'next/link';
-import CardList from '@/components/ui/card/cardOverview/CardList';
 import Button from '@/components/common/Button';
-import Pagination from '@/components/market/Pagination';
+import CardList from '@/components/ui/card/cardOverview/CardList';
 import MyCardsSellBottomSheet from '@/components/market/MyCardsSellBottomSheet';
+import {countFilterValues} from '@/utils/countFilterValues';
 
 export default function MarketplacePage() {
   const [keyword, setKeyword] = useState('');
@@ -20,8 +19,8 @@ export default function MarketplacePage() {
   const [filter, setFilter] = useState({type: '', value: ''});
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [filterCounts, setFilterCounts] = useState(null);
-  const [currentPage, setCurrentPage] = useState(1);
   const [isTabletOrMobile, setIsTabletOrMobile] = useState(false);
+  const [isMyCardsSellOpen, setIsMyCardsSellOpen] = useState(false);
 
   // 브레이크포인트 감지
   useEffect(() => {
@@ -31,8 +30,7 @@ export default function MarketplacePage() {
           '--breakpoint-pc',
         ),
       );
-      const currentWidth = window.innerWidth;
-      return currentWidth < pcMinWidth;
+      return window.innerWidth < pcMinWidth;
     };
 
     const handleResize = () => {
@@ -44,7 +42,7 @@ export default function MarketplacePage() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // 무한스크롤 적용
+  // 무한스크롤 쿼리 (모든 디바이스에서 사용)
   const {
     data: infiniteData,
     fetchNextPage,
@@ -61,39 +59,21 @@ export default function MarketplacePage() {
         filterType: filter.type,
         filterValue: filter.value,
       }),
-    enabled: !isTabletOrMobile,
+    enabled: true,
     getNextPageParam: lastPage =>
       lastPage.currentPage < lastPage.totalPages
         ? lastPage.currentPage + 1
         : undefined,
   });
 
-  // 페이지네이션 적용
-  const {data: pageData} = useQuery({
-    queryKey: ['marketCards-page', keyword, sort, filter, currentPage],
-    queryFn: () =>
-      fetchMarketCards({
-        pageParam: currentPage,
-        take: 4,
-        keyword,
-        sort,
-        filterType: filter.type,
-        filterValue: filter.value,
-      }),
-    enabled: isTabletOrMobile,
-  });
-
-  // '나의 포토카드 판매하기' 바텀시트의 열림/닫힘 상태
-  const [isMyCardsSellOpen, setIsMyCardsSellOpen] = useState(false);
-
   // 무한 스크롤 트리거용 ref
   const {ref: loaderRef, inView} = useInView({threshold: 0.8});
 
   useEffect(() => {
-    if (!isTabletOrMobile && inView && hasNextPage && !isFetchingNextPage) {
+    if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [inView, isTabletOrMobile, hasNextPage, isFetchingNextPage]);
+  }, [inView, hasNextPage, isFetchingNextPage]);
 
   // 필터 값 카운트
   useEffect(() => {
@@ -103,27 +83,7 @@ export default function MarketplacePage() {
       keyword: '',
       sort: 'latest',
     }).then(res => {
-      const rawCards = res.result;
-
-      const counts = {
-        grade: {},
-        genre: {},
-        method: {},
-        soldOut: {},
-      };
-
-      rawCards.forEach(card => {
-        // 등급
-        counts.grade[card.cardGrade] = (counts.grade[card.cardGrade] || 0) + 1;
-
-        // 장르
-        counts.genre[card.cardGenre] = (counts.genre[card.cardGenre] || 0) + 1;
-
-        // 매진 여부
-        const isSoldOut = card.quantityLeft === 0 ? 'true' : 'false';
-        counts.soldOut[isSoldOut] = (counts.soldOut[isSoldOut] || 0) + 1;
-      });
-
+      const counts = countFilterValues(res.result);
       setFilterCounts(counts);
     });
   }, []);
@@ -136,6 +96,8 @@ export default function MarketplacePage() {
     {label: '높은 가격순', value: 'price-desc'},
     {label: '오래된순', value: 'oldest'},
   ];
+
+  const cards = infiniteData?.pages.flatMap(p => p.result) ?? [];
 
   return (
     <>
@@ -166,9 +128,7 @@ export default function MarketplacePage() {
               placeholder="검색"
             />
           </div>
-
           <hr className="border-gray400 mt-[15px]" />
-
           {/* 모바일 필터 + 정렬 */}
           <div className="flex tablet:hidden justify-between items-center">
             <button
@@ -272,33 +232,14 @@ export default function MarketplacePage() {
               />
             </div>
           </div>
-
-          {/* 카드 목록 그리드 */}
-          {/* TODO: 카드리스트 컴포넌트에서 그리드 처리하도록 수정해야 함. */}
-          <div className="w-full">
-            {isTabletOrMobile ? (
-              <>
-                <CardList
-                  cards={pageData?.result ?? []}
-                  className="grid gap-4 grid-cols-2"
-                />
-                <Pagination
-                  currentPage={currentPage}
-                  totalPages={pageData?.totalPages ?? 1}
-                  onPageChange={setCurrentPage}
-                />
-              </>
-            ) : (
-              <>
-                <CardList
-                  cards={infiniteData?.pages.flatMap(p => p.result) ?? []}
-                  className="grid gap-20 grid-cols-3 w-full"
-                />
-                <div ref={loaderRef} className="h-10" />
-              </>
-            )}
-          </div>
-
+          {/* 카드 목록 */}
+          <CardList
+            cards={cards}
+            className={`grid gap-4 ${
+              isTabletOrMobile ? 'grid-cols-2' : 'gap-20 grid-cols-3'
+            }`}
+          />
+          <div ref={loaderRef} className="h-10" />
           {/* 모바일 하단 고정 바 + 필터 바텀시트 */}
           <div className="tablet:hidden">
             <FilterBottomSheet
@@ -325,7 +266,7 @@ export default function MarketplacePage() {
         </div>
       </div>
 
-      {/* MyCardsSellBottomSheet 컴포넌트 */}
+      {/* 나의 포토카드 판매하기 바텀시트 */}
       <MyCardsSellBottomSheet
         isOpen={isMyCardsSellOpen}
         onClose={() => setIsMyCardsSellOpen(false)}

--- a/src/app/my-gallary/page.jsx
+++ b/src/app/my-gallary/page.jsx
@@ -1,0 +1,314 @@
+'use client';
+
+import {useEffect, useState} from 'react';
+import {useQuery, useInfiniteQuery} from '@tanstack/react-query';
+import {useInView} from 'react-intersection-observer';
+import Image from 'next/image';
+import Button from '@/components/common/Button';
+import SearchInput from '@/components/ui/input/SearchInput';
+import DropdownInput from '@/components/ui/input/DropdownInput';
+import FilterBottomSheet from '@/components/market/FilterBottomSheet';
+import CardList from '@/components/ui/card/cardOverview/CardList';
+import Pagination from '@/components/market/Pagination';
+import {fetchMyGalleryCards} from '@/lib/api/gallaryApi';
+
+export default function MyGalleryPage() {
+  const [keyword, setKeyword] = useState('');
+  const [sort, setSort] = useState('latest');
+  const [filter, setFilter] = useState({type: '', value: ''});
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [filterCounts, setFilterCounts] = useState(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isTabletOrMobile, setIsTabletOrMobile] = useState(false);
+  const [totalOwnedCount, setTotalOwnedCount] = useState(0);
+
+  useEffect(() => {
+    const getIsMobileOrTablet = () => {
+      const pcMinWidth = parseInt(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          '--breakpoint-pc',
+        ),
+      );
+      return window.innerWidth < pcMinWidth;
+    };
+
+    const handleResize = () => setIsTabletOrMobile(getIsMobileOrTablet());
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // 필터 값 카운트
+  useEffect(() => {
+    fetchMyGalleryCards({
+      pageParam: 1,
+      take: 1, // count만 필요하므로 적은 수
+      keyword: '',
+    }).then(res => {
+      setTotalOwnedCount(res.totalCount);
+
+      const counts = {
+        grade: {},
+        genre: {},
+      };
+
+      rawCards.forEach(card => {
+        // 등급
+        counts.grade[card.cardGrade] = (counts.grade[card.cardGrade] || 0) + 1;
+
+        // 장르
+        counts.genre[card.cardGenre] = (counts.genre[card.cardGenre] || 0) + 1;
+      });
+
+      setFilterCounts(counts);
+    });
+  }, []);
+
+  const {
+    data: infiniteData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ['myGallery', keyword, sort, filter],
+    queryFn: ({pageParam = 1}) =>
+      fetchMyGalleryCards({
+        pageParam,
+        take: 12,
+        keyword,
+        sort,
+        filterType: filter.type,
+        filterValue: filter.value,
+      }),
+    getNextPageParam: lastPage =>
+      lastPage.currentPage < lastPage.totalPages
+        ? lastPage.currentPage + 1
+        : undefined,
+    enabled: !isTabletOrMobile,
+  });
+
+  const {data: pageData} = useQuery({
+    queryKey: ['myGalleryPage', keyword, sort, filter, currentPage],
+    queryFn: () =>
+      fetchMyGalleryCards({
+        pageParam: currentPage,
+        take: 4,
+        keyword,
+        sort,
+        filterType: filter.type,
+        filterValue: filter.value,
+      }),
+    enabled: isTabletOrMobile,
+  });
+
+  const effectiveData = isTabletOrMobile ? pageData : infiniteData?.pages?.[0];
+  const totalCount = effectiveData?.totalCount ?? 0;
+  const nickname = effectiveData?.nickname ?? '유저';
+  const countsByGrade = effectiveData?.countsByGrade ?? {};
+
+  const rawCards = isTabletOrMobile
+    ? pageData?.list ?? []
+    : infiniteData?.pages.flatMap(p => p.list) ?? [];
+
+  // count 값을 그대로 quantity로 사용
+  const groupedCards = rawCards.reduce((acc, card) => {
+    const key = card.photoCardId;
+    if (!acc[key]) {
+      acc[key] = {
+        ...card,
+        quantity: card.count ?? 1, // 👈 여기서 count → quantity
+      };
+    }
+    return acc;
+  }, {});
+
+  const deduplicatedCards = Object.values(groupedCards);
+
+  const {ref: loaderRef, inView} = useInView({threshold: 0.8});
+
+  useEffect(() => {
+    if (!isTabletOrMobile && inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, isTabletOrMobile, hasNextPage, isFetchingNextPage]);
+
+  const handleSearch = value => setKeyword(value);
+
+  const sortOptions = [
+    {label: '최신순', value: 'latest'},
+    {label: '오래된순', value: 'oldest'},
+  ];
+
+  console.log(deduplicatedCards);
+  return (
+    <>
+      <div className="max-w-[1480px] mx-auto">
+        {/* 데스크탑/태블릿 헤더 */}
+        <div className="hidden tablet:flex justify-between items-center">
+          <h1 className="font-baskin text-[48px] pc:text-[62px] font-bold text-white">
+            마이갤러리
+          </h1>
+          <Button
+            role="create"
+            variant="primary"
+            fullWidth={false}
+            onClick={() => {}} // TODO: 포토카드 생성페이지와 연결
+          >
+            포토카드 생성하기
+          </Button>
+        </div>
+        {/* 유저 정보, 수량 */}
+        <p className="text-white mb-2">
+          {nickname}님이 보유한 포토카드{' '}
+          <span className="text-main">({totalOwnedCount}장)</span>
+        </p>
+        {/* 카드장르별 수량 */}
+        <div className="flex gap-2 mb-3 flex-wrap">
+          {['COMMON', 'RARE', 'SUPER_RARE', 'LEGENDARY'].map(grade => (
+            <span
+              key={grade}
+              className={`text-sm px-3 py-1 border rounded font-semibold ${
+                grade === 'COMMON'
+                  ? 'border-ㅡmain text-main'
+                  : grade === 'RARE'
+                  ? 'border-blue text-blue'
+                  : grade === 'SUPER_RARE'
+                  ? 'border-purple text-purple'
+                  : 'border-pink text-pink'
+              }`}
+            >
+              {grade.replace('_', ' ')} {countsByGrade[grade] ?? 0}장
+            </span>
+          ))}
+        </div>
+
+        <div className="space-y-[15px] pb-[80px]">
+          <hr className="border-gray400 mt-[15px]" />
+          {/* 모바일 필터 + 검색 */}
+          <div className="flex tablet:hidden items-center gap-2 mb-4">
+            {/* 필터 버튼 */}
+            <button
+              onClick={() => setIsFilterOpen(true)}
+              className="w-[35px] h-[35px] border border-white rounded flex items-center justify-center shrink-0"
+            >
+              <Image
+                src="/icons/ic_filter.svg"
+                alt="필터"
+                width={20}
+                height={20}
+              />
+            </button>
+
+            {/* 검색창 */}
+            <SearchInput
+              name="query"
+              value={keyword}
+              onChange={e => setKeyword(e.target.value)}
+              onSearch={handleSearch}
+              placeholder="검색"
+              className="flex-grow h-[35px]"
+            />
+          </div>
+
+          {/* 데스크탑/태블릿: 검색 + 필터 + 정렬 */}
+          <div className="hidden tablet:flex flex-wrap gap-2 py-2 items-center justify-between">
+            <div className="flex flex-wrap items-center max-w-full tablet:max-w-[calc(100%-180px)]">
+              {/* 검색창 */}
+              <div>
+                <SearchInput
+                  name="query"
+                  value={keyword}
+                  onChange={e => setKeyword(e.target.value)}
+                  onSearch={handleSearch}
+                  placeholder="검색"
+                  className="!w-[160px] pc:!w-[320px]"
+                />
+              </div>
+
+              {/* TODO: 필터 중복 선택 가능하도록 수정해야 함. */}
+              {/* TODO: 드롭다운 메뉴 너비/폰트 조정해야 함. */}
+              <div className="tablet:ml-[30px] pc:ml-[60px]">
+                <DropdownInput
+                  className="border-none !px-0"
+                  name="grade"
+                  value={filter.type === 'grade' ? filter.value : ''}
+                  onChange={({target}) =>
+                    setFilter({type: 'grade', value: target.value})
+                  }
+                  placeholder="등급"
+                  options={[
+                    {label: 'COMMON', value: 'COMMON'},
+                    {label: 'RARE', value: 'RARE'},
+                    {label: 'SUPER_RARE', value: 'SUPER_RARE'},
+                    {label: 'LEGENDARY', value: 'LEGENDARY'},
+                  ]}
+                />
+              </div>
+
+              <div className="tablet:ml-[25px] pc:ml-[45px]">
+                <DropdownInput
+                  className="border-none !px-0"
+                  name="genre"
+                  value={filter.type === 'genre' ? filter.value : ''}
+                  onChange={({target}) =>
+                    setFilter({type: 'genre', value: target.value})
+                  }
+                  placeholder="장르"
+                  options={[
+                    {label: '여행', value: 'TRAVEL'},
+                    {label: '풍경', value: 'LANDSCAPE'},
+                    {label: '인물', value: 'PORTRAIT'},
+                    {label: '사물', value: 'OBJECT'},
+                  ]}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <CardList
+              cards={deduplicatedCards}
+              className={`grid ${
+                isTabletOrMobile ? 'grid-cols-2' : 'grid-cols-3'
+              } gap-4`}
+            />
+
+            {isTabletOrMobile ? (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={pageData?.totalPages ?? 1}
+                onPageChange={setCurrentPage}
+              />
+            ) : (
+              <div ref={loaderRef} className="h-10" />
+            )}
+          </div>
+
+          {/* 모바일 하단 고정 바 + 필터 바텀시트 */}
+          <div className="tablet:hidden">
+            <FilterBottomSheet
+              isOpen={isFilterOpen}
+              onClose={() => setIsFilterOpen(false)}
+              onApply={filter => setFilter(filter)}
+              filterCounts={filterCounts}
+              tabs={['grade', 'genre']}
+              selectedFilter={filter}
+            />
+
+            <div className="fixed bottom-[15px] left-[15px] right-[15px] h-[55px] px-[18px] bg-main z-10 text-center rounded-xs">
+              <Button
+                role="sell"
+                variant="primary"
+                fullWidth
+                className="w-full h-full"
+                onClick={() => {}} // TODO: 포토카드 생성페이지와 연결
+              >
+                나의 포토카드 생성하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/market/FilterBottomSheet.jsx
+++ b/src/components/market/FilterBottomSheet.jsx
@@ -1,43 +1,38 @@
-"use client";
+'use client';
 
-import Image from "next/image";
-import { useEffect, useState } from "react";
-import Button from "../common/Button";
+import Image from 'next/image';
+import {useEffect, useState} from 'react';
+import Button from '../common/Button';
+import {formatCardGrade} from '@/utils/formatCardGrade';
+import gradeStyles from '@/utils/gradeStyles';
 
 const fullTabConfig = {
   grade: {
-    label: "등급",
-    options: ["COMMON", "RARE", "SUPER_RARE", "LEGENDARY"],
+    label: '등급',
+    options: ['COMMON', 'RARE', 'SUPER_RARE', 'LEGENDARY'],
   },
   genre: {
-    label: "장르",
-    options: ["TRAVEL", "LANDSCAPE", "PORTRAIT", "OBJECT"],
+    label: '장르',
+    options: ['TRAVEL', 'LANDSCAPE', 'PORTRAIT', 'OBJECT'],
   },
   soldOut: {
-    label: "매진 여부",
-    options: ["false", "true"],
+    label: '매진 여부',
+    options: ['false', 'true'],
   },
 };
 
 // filter value 매핑
 const labelMap = {
-  COMMON: "COMMON",
-  RARE: "RARE",
-  SUPER_RARE: "SUPER RARE",
-  LEGENDARY: "LEGENDARY",
-  TRAVEL: "여행",
-  LANDSCAPE: "풍경",
-  PORTRAIT: "인물",
-  OBJECT: "사물",
-  true: "판매 완료",
-  false: "판매 중",
-};
-
-const colorMap = {
-  COMMON: "text-main",
-  RARE: "text-blue",
-  SUPER_RARE: "text-purple",
-  LEGENDARY: "text-pink",
+  COMMON: 'COMMON',
+  RARE: 'RARE',
+  SUPER_RARE: 'SUPER RARE',
+  LEGENDARY: 'LEGENDARY',
+  TRAVEL: '여행',
+  LANDSCAPE: '풍경',
+  PORTRAIT: '인물',
+  OBJECT: '사물',
+  true: '판매 완료',
+  false: '판매 중',
 };
 
 export default function FilterBottomSheet({
@@ -45,17 +40,17 @@ export default function FilterBottomSheet({
   onClose,
   onApply,
   filterCounts,
-  tabs = ["grade", "genre", "soldOut"],
-  selectedFilter = { type: "", value: "" },
+  tabs = ['grade', 'genre', 'soldOut'],
+  selectedFilter = {type: '', value: ''},
 }) {
-  const resolvedTabs = tabs.map((type) => ({
+  const resolvedTabs = tabs.map(type => ({
     type,
     ...fullTabConfig[type],
   }));
 
-  const [selectedTab, setSelectedTab] = useState(resolvedTabs[0]?.type || "");
+  const [selectedTab, setSelectedTab] = useState(resolvedTabs[0]?.type || '');
   const [selectedValues, setSelectedValues] = useState([]);
-  const currentTab = resolvedTabs.find((tab) => tab.type === selectedTab);
+  const currentTab = resolvedTabs.find(tab => tab.type === selectedTab);
 
   // 현재 필터링 중인 탭 보여주기
   useEffect(() => {
@@ -63,10 +58,10 @@ export default function FilterBottomSheet({
 
     if (selectedFilter?.type && tabs.includes(selectedFilter.type)) {
       setSelectedTab(selectedFilter.type);
-      const values = selectedFilter.value?.split(",") ?? [];
+      const values = selectedFilter.value?.split(',') ?? [];
       setSelectedValues(values);
     } else {
-      setSelectedTab(resolvedTabs[0]?.type || "");
+      setSelectedTab(resolvedTabs[0]?.type || '');
       setSelectedValues([]);
     }
   }, [isOpen, selectedFilter, tabs]);
@@ -74,20 +69,20 @@ export default function FilterBottomSheet({
   // 필터 적용 함수
   const handleApply = () => {
     if (selectedValues.length > 0) {
-      onApply({ type: selectedTab, value: selectedValues.join(",") });
+      onApply({type: selectedTab, value: selectedValues.join(',')});
     }
     setSelectedValues([]);
     onClose();
   };
 
   // 필터 토글 함수
-  const toggleValue = (value) => {
-    setSelectedValues((prev) =>
-      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+  const toggleValue = value => {
+    setSelectedValues(prev =>
+      prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value],
     );
   };
 
-  const isSelected = (value) => selectedValues.includes(value);
+  const isSelected = value => selectedValues.includes(value);
 
   if (!isOpen) return null;
 
@@ -115,7 +110,7 @@ export default function FilterBottomSheet({
 
         {/* 탭 */}
         <div className="flex h-[52px] text-sm gap-6 mx-6">
-          {resolvedTabs.map((tab) => {
+          {resolvedTabs.map(tab => {
             const isActive = selectedTab === tab.type;
             const selectedCount = isActive ? selectedValues.length : 0;
 
@@ -124,8 +119,8 @@ export default function FilterBottomSheet({
                 key={tab.type}
                 className={`relative p-4 text-center ${
                   isActive
-                    ? "text-white border-b-1 border-white"
-                    : "text-gray400"
+                    ? 'text-white border-b-1 border-white'
+                    : 'text-gray400'
                 }`}
                 onClick={() => {
                   setSelectedTab(tab.type);
@@ -144,7 +139,7 @@ export default function FilterBottomSheet({
         {/* 옵션 */}
         <div className="flex-1 overflow-y-auto">
           <ul className="flex flex-col">
-            {currentTab?.options.map((opt) => {
+            {currentTab?.options.map(opt => {
               const selected = isSelected(opt);
               const count = filterCounts?.[currentTab.type]?.[opt] || 0;
               return (
@@ -152,24 +147,26 @@ export default function FilterBottomSheet({
                   key={opt}
                   onClick={() => toggleValue(opt)}
                   className={`w-full px-8 py-4 flex justify-between items-center text-sm cursor-pointer ${
-                    selected ? "bg-gray500" : ""
+                    selected ? 'bg-gray500' : ''
                   }`}
                 >
                   <span
                     className={
-                      currentTab.type === "grade"
-                        ? colorMap[opt] || "text-white"
+                      currentTab.type === 'grade'
+                        ? gradeStyles[opt] || 'text-white'
                         : selected
-                        ? "text-white"
-                        : "text-gray300"
+                        ? 'text-white'
+                        : 'text-gray300'
                     }
                   >
-                    {labelMap[opt] || opt}
+                    {currentTab.type === 'grade'
+                      ? formatCardGrade(opt)
+                      : labelMap[opt] || opt}
                   </span>
 
                   <span
                     className={`text-sm ${
-                      selected ? "text-gray100" : "text-gray300"
+                      selected ? 'text-gray100' : 'text-gray300'
                     }`}
                   >
                     {count}개
@@ -202,7 +199,7 @@ export default function FilterBottomSheet({
           >
             {selectedValues.reduce(
               (acc, value) => acc + (filterCounts?.[selectedTab]?.[value] || 0),
-              0
+              0,
             )}
             개 포토보기
           </Button>

--- a/src/lib/api/gallaryApi.js
+++ b/src/lib/api/gallaryApi.js
@@ -20,20 +20,17 @@ export async function fetchMyGalleryCards({
     params.append('filterValue', filterValue);
   }
 
-  const url = `${BASE_API}/api/mypage/cards?${params.toString()}`;
+  const url = `${BASE_API}/api/mypage/idle-cards?${params.toString()}`;
   const res = await fetch(url, {
     credentials: 'include',
   });
 
-  console.log('[FETCH] 응답 status:', res.status);
-
   if (!res.ok) {
     const error = await res.json().catch(() => ({}));
-    console.error('[FETCH] 에러 응답 내용:', error);
+
     throw new Error(error.message || '마이갤러리 불러오기 실패');
   }
 
   const data = await res.json();
-  console.log('[FETCH] 응답 데이터:', data);
   return data;
 }

--- a/src/lib/api/gallaryApi.js
+++ b/src/lib/api/gallaryApi.js
@@ -1,0 +1,39 @@
+const BASE_API = 'http://localhost:5005';
+
+export async function fetchMyGalleryCards({
+  pageParam = 1,
+  take = 4,
+  keyword = '',
+  sort = 'latest',
+  filterType = '',
+  filterValue = '',
+}) {
+  const params = new URLSearchParams({
+    page: pageParam,
+    take,
+    keyword,
+    sort,
+  });
+
+  if (filterType && filterValue) {
+    params.append('filterType', filterType);
+    params.append('filterValue', filterValue);
+  }
+
+  const url = `${BASE_API}/api/mypage/cards?${params.toString()}`;
+  const res = await fetch(url, {
+    credentials: 'include',
+  });
+
+  console.log('[FETCH] 응답 status:', res.status);
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    console.error('[FETCH] 에러 응답 내용:', error);
+    throw new Error(error.message || '마이갤러리 불러오기 실패');
+  }
+
+  const data = await res.json();
+  console.log('[FETCH] 응답 데이터:', data);
+  return data;
+}

--- a/src/utils/countFilterValues.js
+++ b/src/utils/countFilterValues.js
@@ -1,0 +1,28 @@
+export function countFilterValues(cards) {
+  const counts = {
+    grade: {},
+    genre: {},
+    method: {},
+    soldOut: {},
+  };
+
+  cards.forEach(card => {
+    // 등급
+    counts.grade[card.cardGrade] = (counts.grade[card.cardGrade] || 0) + 1;
+
+    // 장르
+    counts.genre[card.cardGenre] = (counts.genre[card.cardGenre] || 0) + 1;
+
+    // 판매 방식
+    if (card.saleMethod) {
+      counts.method[card.saleMethod] =
+        (counts.method[card.saleMethod] || 0) + 1;
+    }
+
+    // 매진 여부
+    const isSoldOut = card.quantityLeft === 0 ? 'true' : 'false';
+    counts.soldOut[isSoldOut] = (counts.soldOut[isSoldOut] || 0) + 1;
+  });
+
+  return counts;
+}


### PR DESCRIPTION
## 주요 변경사항

- 마이갤러리 UI 레이아웃 및 카드 그리드 구현
- getMyCards API 연동 및 유저 보유 카드 렌더링
- 마켓플레이스 전체 무한스크롤 방식 적용
- `FilterBottomSheet` 컴포넌트에 **등급 관련 유틸 함수(`gradeStyles`, `formatCardGrade`) 적용**
- 카드 수량 카운트 계산 로직 → 유틸 함수로 분리(`countFilterValues`)

---

## 🛠 작업한 커밋

- feat: 마이갤러리 UI 구현 및 api 연동
- refactor: FilterBottomSheet에 등급 관련 유틸 함수 적용
- refactor: 마켓페이지 전체 무한스크롤 적용 및 필터 카운트 유틸함수 적용